### PR TITLE
Fix AWeber::Collection#fetch_entry

### DIFF
--- a/lib/aweber.rb
+++ b/lib/aweber.rb
@@ -57,12 +57,12 @@ module AWeber
   @api_endpoint  = "https://api.aweber.com"
   @auth_endpoint = "https://auth.aweber.com"
   
-  class OAuthError < Exception; end
-  class NotFoundError < Exception; end
-  class UnknownRequestError < Exception; end
-  class RateLimitError < Exception; end
-  class ForbiddenRequestError < Exception; end
-  class CreationError < Exception; end
+  class OAuthError < StandardError; end
+  class NotFoundError < StandardError; end
+  class UnknownRequestError < StandardError; end
+  class RateLimitError < StandardError; end
+  class ForbiddenRequestError < StandardError; end
+  class CreationError < StandardError; end
 end
 
 $LOAD_PATH << File.dirname(__FILE__) unless $LOAD_PATH.include?(File.dirname(__FILE__))

--- a/lib/aweber/collection.rb
+++ b/lib/aweber/collection.rb
@@ -123,7 +123,7 @@ module AWeber
     end
 
     def fetch_entry(id)
-      @klass.new(client, get(path).merge(:parent => self))
+      @klass.new(client, get("#{path}/#{id}").merge(:parent => self))
     end
 
     def fetch_next_group()


### PR DESCRIPTION
When accessing a `AWeber::Resource::has_many`, the relation performs a GET request and creates an `AWeber::Collection` from the response, see [here](https://github.com/Privy/AWeber-API-Ruby-Library/blob/master/lib/aweber/resource.rb#L89). This means that for the most part, the individual entries of the collection are already in memory. However, collections only return the first 100 entries by default
> Collections are paginated in groups of 'ws.size' (default: 100) entries starting at the offset 'ws.start' (default: 0). You can specify values for 'ws.start' and 'ws.size' in the query string to control the pagination. You can navigate to other pages by following the 'next_collection_link' and 'prev_collection_link' links.

&mdash; https://labs.aweber.com/docs/reference/1.0#list_collection

For other entries, `AWeber::Collection#fetch_entry` will be called. However this method doesn't include the `id` in the url, so the entry isn't actually fetched. Instead, the original collection is fetched and from that point on that entry contains junk data.

### Other changes
* Made errors inherit from `StandardError`